### PR TITLE
11 Fix matching locator "#settingsnav" not found

### DIFF
--- a/tests/behat/behat_report_allylti.php
+++ b/tests/behat/behat_report_allylti.php
@@ -58,10 +58,6 @@ class behat_report_allylti extends behat_base {
             $node = $this->find('xpath', '//div[@id="settingsnav"]//ul//li//p//a[text()="Reports"]');
             $node->click();
         }
-
-        $linkselector = '//a[contains(@href, "report/allylti/launch.php?reporttype=course")]';
-        $node = $this->find('xpath', $linkselector);
-        $node->click();
     }
 
     /**


### PR DESCRIPTION
Previously the tests in view_report.feature failed with Firefox (but not Chrome).  Apparently this is because "Accessibility report" was clicked twice in succession.

Proposed fix for #11 . This removes the first click of "Accessibility report" from behat_report_allylti->navigate_ax_report() so there is now only one click on this link. With this change the test now passes with both headlesschromedriver and headlessfirefox (on my system).