### PR TITLE
9 Migrate output callback to hook

### DIFF
--- a/classes/local/hook_callbacks.php
+++ b/classes/local/hook_callbacks.php
@@ -14,24 +14,24 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * This is a one-line short description of the file.
- *
- * You can have a rather longer description of the file as well,
- * if you like, and it can span multiple lines.
- *
- * @package    report_allylti
- * @author     Sam Chaffee
- * @copyright  Copyright (c) 2016 Open LMS (https://www.openlms.net) / 2023 Anthology Inc. and its affiliates
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-defined('MOODLE_INTERNAL') || die();
+namespace report_allylti\local;
 
-$plugin->version      = 2024060304;        // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2024042200;        // Requires Moodle 4.4.
-$plugin->release      = '4.3.1';
-$plugin->component    = 'report_allylti';  // Full name of the plugin (used for diagnostics).
-$plugin->dependencies = [
-    'tool_ally'      => 2024060300,
-    'filter_ally'    => 2024060300,
-];
+use core\hook\output\before_standard_head_html_generation;
+
+/**
+ * Hook callbacks for report_allylti.
+ * @package    report_allylti
+ * @copyright  2024 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Leon Stringer <leon.stringer@ucl.ac.uk>
+ */
+class hook_callbacks {
+    /**
+     * Callback to add JavaScript module to page.
+     * @param \core\hook\output\before_standard_head_html_generation $hook
+     */
+    public static function before_standard_head_html_generation(before_standard_head_html_generation $hook): void {
+        global $PAGE;
+        $PAGE->requires->js_call_amd('report_allylti/main', 'init');
+    }
+}

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -15,23 +15,19 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * This is a one-line short description of the file.
- *
- * You can have a rather longer description of the file as well,
- * if you like, and it can span multiple lines.
+ * Hooks for report_allylti.
  *
  * @package    report_allylti
- * @author     Sam Chaffee
- * @copyright  Copyright (c) 2016 Open LMS (https://www.openlms.net) / 2023 Anthology Inc. and its affiliates
+ * @copyright  2024 onwards University College London {@link https://www.ucl.ac.uk/}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Leon Stringer <leon.stringer@ucl.ac.uk>
  */
+
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version      = 2024060304;        // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2024042200;        // Requires Moodle 4.4.
-$plugin->release      = '4.3.1';
-$plugin->component    = 'report_allylti';  // Full name of the plugin (used for diagnostics).
-$plugin->dependencies = [
-    'tool_ally'      => 2024060300,
-    'filter_ally'    => 2024060300,
+$callbacks = [
+    [
+        'hook' => \core\hook\output\before_standard_head_html_generation::class,
+        'callback' => \report_allylti\local\hook_callbacks::class . '::before_standard_head_html_generation',
+    ],
 ];

--- a/lib.php
+++ b/lib.php
@@ -40,8 +40,3 @@ function report_allylti_extend_navigation_course($navigation, $course, $context)
         $navigation->add(get_string('coursereport', 'report_allylti'), $url, navigation_node::TYPE_SETTING, null, null, $icon);
     }
 }
-
-function report_allylti_before_standard_html_head() {
-    global $PAGE;
-    $PAGE->requires->js_call_amd('report_allylti/main', 'init');
-}


### PR DESCRIPTION
Migrate before_standard_html_head() to hook to reflect change in Moodle 4.4 (see MDL-81144).

Proposed fix for #9 . Note that a version bump is needed, and $plugin->requires needs increasing to Moodle 4.4.